### PR TITLE
More functions, operators and syntax

### DIFF
--- a/company-kusto.el
+++ b/company-kusto.el
@@ -1,0 +1,39 @@
+;;; company-kusto.el --- company-mode completion backend for kusto-mode  -*- lexical-binding: t -*-
+
+;; Copyright © 2019, by Hindol Adhya
+
+;; Author: Hindol Adhya <hindol.github.io>
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+;;
+;; In Emacs >= 26, company-capf is used instead.
+
+;;; Code:
+
+(require 'company)
+(require 'cl-lib)
+(require 'kusto-mode)
+
+(defconst company-kusto-completions
+  (append kusto-operators
+          kusto-builtin-functions
+          kusto-data-types))
+
+;;;###autoload
+(defun company-kusto (command &optional arg &rest ignored)
+  "`company-mode' completion backend for `kusto-mode'."
+  (interactive (list 'interactive))
+  (cl-case command
+    (interactive (company-begin-backend 'company-kusto))
+    (prefix (and (eq major-mode 'kusto-mode)
+                 (company-grab-symbol)))
+    (candidates
+     (cond
+      ((company-grab-symbol)
+       (all-completions arg company-kusto-completions))))
+    (sorted t)))
+
+(provide 'company-kusto)
+;;; company-kusto.el ends here

--- a/kusto-mode.el
+++ b/kusto-mode.el
@@ -1,8 +1,8 @@
 ;;; kusto-mode.el --- sample major mode for editing LSL. -*- coding: utf-8; lexical-binding: t; -*-
 
-;; Copyright © 2019, by Tatu Lahtela
+;; Copyright © 2019, by Hindol Adhya, Tatu Lahtela
 
-;; Author: Tatu Lahtela <tatu@lahtela.me>
+;; Author: Hindol Adhya, Tatu Lahtela <tatu@lahtela.me>
 ;; Version: 0.0.1
 ;; Created: 2019-09-12
 ;; Keywords: languages
@@ -20,30 +20,127 @@
 
 ;;; Code:
 
+(defconst kusto-data-types
+  '("bool" "datetime" "dynamic" "guid" "int" "long" "real" "string" "timespan"
+  "decimal"))
+
+(defconst kusto-operators
+  (let* ((x-tabular-operators
+          '("as" "consume" "count" "datatable" "distinct" "evaluate" "extend"
+            "externaldata" "facet" "find" "fork" "getschema" "invoke" "join"
+            "limit" "lookup" "make-series" "mv-apply" "mv-expand" "order"
+            "project" "project-away" "project-rename" "project-reorder" "parse"
+            "parse-where" "partition" "print" "range" "reduce" "render" "sample"
+            "sample-distinct" "search" "serialize" "sort" "summarize" "take"
+            "top" "top-nested" "top-hitters" "union" "where"))
+         (x-scalar-operators
+          '("has" "has_cs" "hasprefix" "hasprefix_cs" "hassuffix" "hassuffix_cs"
+            "contains" "contains_cs" "startswith" "startswith_cs" "endswith"
+            "endswith_cs" "matches regex" "in" "in~" "has_any")))
+    (append x-tabular-operators
+            x-scalar-operators)))
+
+(defconst kusto-builtin-functions
+  (let* ((x-binary-functions
+          '("binary_and" "binary_not" "binary_or" "binary_shift_left"
+            "binary_shift_right" "binary_xor" "bitset_count_ones"))
+         (x-conversion-functions
+          '("tobool" "todatetime" "todouble" "toreal" "tostring" "totimespan"))
+         (x-time-functions
+          '("ago" "datetime_add" "datetime_part" "datetime_diff" "dayofmonth"
+            "dayofweek" "dayofyear" "endofday" "endofmonth" "endofweek"
+            "endofyear" "format_datetime" "format_timespan" "getmonth" "getyear"
+            "hourofday" "make_datetime" "make_timespan" "monthofyear" "now"
+            "startofday" "startofmonth" "startofweek" "startofyear" "todatetime"
+            "totimespan" "weekofyear"))
+         (x-array-functions
+          '("array_concat" "array_iif" "array_index_of" "array_length"
+            "array_slice" "array_split" "bag_keys" "pack" "pack_all" "pack_array"
+            "repeat" "set_difference" "set_has_element" "set_intersect"
+            "set_union" "treepath" "zip"))
+         (x-window-functions
+          '("next" "prev" "row_cumsum" "row_number"))
+         (x-flow-control-functions
+          '("toscalar"))
+         (x-mathematical-functions
+          '("abs" "acos" "asin" "atan" "atan2" "beta_cdf" "beta_inv" "beta_pdf"
+            "cos" "cot" "degrees" "exp" "exp10" "exp2" "gamma" "hash"
+            "hash_combine" "hash_many" "isfinite" "isinf" "isnan" "log" "log10"
+            "log2" "loggamma" "not" "pi" "pow" "radians" "rand" "range" "round"
+            "sign" "sin" "sqrt" "tan" "welch_test"))
+         (x-metadata-functions
+          '("column_ifexists" "current_cluster_endpoint" "current_database"
+            "current_principal" "current_principal_details"
+            "current_principal_is_member_of" "cursor_after" "estimate_data_size"
+            "extent_id" "extent_tags" "ingestion_time"))
+         (x-rounding-functions
+          '("bin" "bin_at" "ceiling" "floor"))
+         (x-conditional-functions
+          '("case" "coalesce" "iif" "iff" "max_of" "min_of"))
+         (x-series-functions
+          '("series_add" "series_divide" "series_equals" "series_greater"
+          "series_greater_equals" "series_less" "series_less_equals"
+          "series_multiply" "series_not_equals" "series_subtract"
+          "series_decompose" "series_decompose_anomalies"
+          "series_decompose_forecast" "series_fill_backward" "series_fill_const"
+          "series_fill_forward" "series_fill_linear" "series_fir"
+          "series_fit_2lines" "series_fit_2lines_dynamic" "series_fit_line"
+          "series_fit_line_dynamic" "series_iir" "series_outliers"
+          "series_pearson_correlation" "series_periods_detect"
+          "series_periods_validate" "series_seasonal" "series_stats"
+          "series_stats_dynamic"))
+         (x-string-functions
+          '("base64_encode_tostring" "base64_decode_tostring"
+          "base64_decode_toarray" "countof" "extract" "extract_all"
+          "extractjson" "indexof" "isempty" "isnotempty" "isnotnull" "isnull"
+          "parse_csv" "parse_ipv4" "parse_json" "parse_url" "parse_urlquery"
+          "parse_version" "replace" "reverse" "split" "strcat" "strcat_delim"
+          "strcmp" "strlen" "strrep" "substring" "toupper" "translate" "trim"
+          "trim_end" "trim_start" "url_decode" "url_encode"))
+         (x-ipv4-functions
+          '("ipv4_compare" "ipv4_is_match" "parse_ipv4" "parse_ipv4_mask"))
+         (x-type-functions '("gettype"))
+         (x-aggregation-functions
+          '("dcount_hll" "hll_merge" "percentile_tdigest" "percentrank_tdigest"
+          "rank_tdigest" "tdigest_merge"))
+         (x-geospatial-functions
+          '("geo_distance_2points" "geo_geohash_to_central_point"
+          "geo_point_in_circle" "geo_point_to_geohash")))
+    (append x-binary-functions
+            x-conversion-functions
+            x-time-functions
+            x-array-functions
+            x-window-functions
+            x-flow-control-functions
+            x-mathematical-functions
+            x-metadata-functions
+            x-rounding-functions
+            x-conditional-functions
+            x-series-functions
+            x-string-functions
+            x-ipv4-functions
+            x-type-functions
+            x-aggregation-functions
+            x-geospatial-functions)))
+
 ;; create the list for font-lock.
 ;; each category of keyword is given a particular face
 (setq kusto-font-lock-keywords
-      (let* (
-             ;; define several category of keywords
-             (x-keywords '("summarize" "filter" "where" "project" "order by" "let" "as" "inner" "outer" "on" "as" "union" "join" "and" "or"))
-             (x-types '(""))
-             (x-constants '(""))
-             (x-events '(""))
-             (x-functions '("count" "datetime" "toint" "tolong" "tostring" "any" "anyif" "arg_max" "arg_min" "avg" "avgif" "buildschema" "count" "countif" "dcount" "dcountif" "hll" "hll_merge" "make_bag" "make_list" "make_set" "max" "maxif" "min" "minif" "percentiles" "stdev" "stdevif" "stdevp" "sum" "sumif" "tdigest" "tdigest_merge" "variance" "varianceif" "variancep" "ago"))
+      (let* ((x-keywords kusto-operators)
+             (x-builtins kusto-builtin-functions)
+             (x-datatypes kusto-data-types)
 
-             ;; generate regex string for each category of keywords
-             (x-keywords-regexp (regexp-opt x-keywords 'words))
-             (x-types-regexp (regexp-opt x-types 'words))
-             (x-constants-regexp (regexp-opt x-constants 'words))
-             (x-events-regexp (regexp-opt x-events 'words))
-             (x-functions-regexp (regexp-opt x-functions 'words)))
+             (x-keywords-regexp (regexp-opt x-keywords 'symbols))
+             (x-builtins-regexp (regexp-opt x-builtins 'symbols))
+             (x-datatypes-regexp (regexp-opt x-datatypes 'symbols)))
 
-        `(
-          (,x-types-regexp . font-lock-type-face)
-          (,x-constants-regexp . font-lock-constant-face)
-          (,x-events-regexp . font-lock-builtin-face)
-          (,x-functions-regexp . font-lock-function-name-face)
-          (,x-keywords-regexp . font-lock-keyword-face)
+        `((, "'[^']*'\\|\"[^\"]*\"" . font-lock-string-face)
+          (, x-builtins-regexp . font-lock-builtin-face)
+          (, x-datatypes-regexp . font-lock-builtin-face)
+          (, x-keywords-regexp . font-lock-keyword-face)
+          (, "\\<\\([[:digit:]]+\\)\\>" . font-lock-constant-face)
+          (, "==\\|!=\\|=~\\|!~" . font-lock-keyword-face)
+          (, "!\\|~" . font-lock-negation-char-face)
           ;; note: order above matters, because once colored, that part won't change.
           ;; in general, put longer words first
           )))
@@ -71,7 +168,7 @@
     (indent-line-to indent-col)))
 
 ;;;###autoload
-(define-derived-mode kusto-mode text-mode "kusto mode"
+(define-derived-mode kusto-mode text-mode "Kusto"
   "Major mode for editing Kusto Query Language"
   (make-local-variable 'kusto-indent-offset)
   (set (make-local-variable 'indent-line-function) 'kusto-indent-line)


### PR DESCRIPTION
- Almost complete list of functions and operators.
- Syntax highlight for strings and numbers.
- A simple company backend for autocompletion.

I am using this config in Doom Emacs,

```elisp
(use-package! kusto-mode
  :config
  (add-to-list 'auto-mode-alist '("\\.kql\\'" . kusto-mode)))

(use-package! company-kusto
  :after kusto-mode
  :config
  (set-company-backend! 'kusto-mode '(company-kusto)))
```